### PR TITLE
Render textures with TRIANGLE_STRIP

### DIFF
--- a/src/quad.cr
+++ b/src/quad.cr
@@ -13,9 +13,6 @@ class Glove::Quad
       [
         0_f32, 0_f32,       0_f32,         texture_height,
         0_f32, height,      0_f32,         0_f32,
-        width, height,      texture_width, 0_f32,
-
-        0_f32, 0_f32,       0_f32,         texture_height,
         width, 0_f32,       texture_width, texture_height,
         width, height,      texture_width, 0_f32,
       ]

--- a/src/renderer.cr
+++ b/src/renderer.cr
@@ -72,7 +72,7 @@ class Glove::Renderer
 
       quad = quad_for(entity)
       gl_checked(LibGL.bind_vertex_array(quad.vertex_array_id))
-      gl_checked(LibGL.draw_arrays(LibGL::TRIANGLES, 0, quad.vertices.size))
+      gl_checked(LibGL.draw_arrays(LibGL::TRIANGLE_STRIP, 0, quad.vertices.size))
       gl_checked(LibGL.bind_vertex_array(0))
     end
 


### PR DESCRIPTION
This simplifies the texture vertices layout a bit and slightly improves performance by using `TRIANGLE_STRIP` rendering.