### PR TITLE
Convert specs to use spec, not spec2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,6 @@
 .PHONY: default
 default: spec
 
-.PHONY: deps
-deps: lib
-
-lib: shard.yml
-	@echo "*** Installing dependencies…"
-	crystal deps
-	mkdir -p `dirname $@`
-	touch $@
-	@echo
-
 .PHONY: ext
 ext:
 	@echo "*** Building ext…"
@@ -25,7 +15,7 @@ doc:
 	@echo
 
 .PHONY: spec
-spec: deps ext
+spec: ext
 	@echo "*** Testing…"
 	crystal spec
 	@echo

--- a/shard.lock
+++ b/shard.lock
@@ -1,6 +1,0 @@
-version: 1.0
-shards:
-  spec2:
-    github: waterlink/spec2.cr
-    commit: f3d8aca8165d8a6ec7681b4355b5ee8b1d597a68
-

--- a/shard.yml
+++ b/shard.yml
@@ -6,10 +6,5 @@ authors:
 
 license: MIT
 
-dependencies:
-  spec2:
-    github: waterlink/spec2.cr
-    branch: master
-
 scripts:
   postinstall: cd src/ext && make

--- a/spec/components/transform_spec.cr
+++ b/spec/components/transform_spec.cr
@@ -1,139 +1,148 @@
-require "spec2"
+require "spec"
 require "../src/glove"
 
-Spec2.describe Glove::Components::Transform do
-  subject { Glove::Components::Transform.new }
-
+describe Glove::Components::Transform do
   describe "#initialize" do
     it "sets reasonable defaults" do
-      expect(subject.width).to eq(0)
-      expect(subject.height).to eq(0)
-      expect(subject.translate_x).to eq(0)
-      expect(subject.translate_y).to eq(0)
-      expect(subject.angle).to eq(0)
-      expect(subject.scale_x).to eq(1)
-      expect(subject.scale_y).to eq(1)
-      expect(subject.anchor_x).to eq(0.5)
-      expect(subject.anchor_y).to eq(0.5)
+      transform = Glove::Components::Transform.new
+
+      transform.width.should eq(0)
+      transform.height.should eq(0)
+      transform.translate_x.should eq(0)
+      transform.translate_y.should eq(0)
+      transform.angle.should eq(0)
+      transform.scale_x.should eq(1)
+      transform.scale_y.should eq(1)
+      transform.anchor_x.should eq(0.5)
+      transform.anchor_y.should eq(0.5)
     end
   end
 
   describe "#bounds" do
     context "by default" do
       it "returns the proper bounds" do
-        expect(subject.bounds.width).to eq(0)
-        expect(subject.bounds.height).to eq(0)
+        transform = Glove::Components::Transform.new
 
-        expect(subject.bounds.top).to eq(0)
-        expect(subject.bounds.bottom).to eq(0)
+        transform.bounds.width.should eq(0)
+        transform.bounds.height.should eq(0)
 
-        expect(subject.bounds.left).to eq(0)
-        expect(subject.bounds.right).to eq(0)
+        transform.bounds.top.should eq(0)
+        transform.bounds.bottom.should eq(0)
+
+        transform.bounds.left.should eq(0)
+        transform.bounds.right.should eq(0)
       end
     end
 
     context "with a width and height" do
-      before do
-        subject.width = 100_f32
-        subject.height = 200_f32
-      end
-
       it "returns the proper bounds" do
-        expect(subject.bounds.width).to eq(100)
-        expect(subject.bounds.height).to eq(200)
+        transform = Glove::Components::Transform.new
+        transform.width = 100_f32
+        transform.height = 200_f32
 
-        expect(subject.bounds.top).to eq(100)
-        expect(subject.bounds.bottom).to eq(-100)
+        transform.bounds.width.should eq(100)
+        transform.bounds.height.should eq(200)
 
-        expect(subject.bounds.left).to eq(-50)
-        expect(subject.bounds.right).to eq(50)
+        transform.bounds.top.should eq(100)
+        transform.bounds.bottom.should eq(-100)
+
+        transform.bounds.left.should eq(-50)
+        transform.bounds.right.should eq(50)
       end
 
       context "translated" do
-        before do
-          subject.translate_x = 10_f32
-          subject.translate_y = 20_f32
-        end
-
         it "returns the proper bounds" do
-          expect(subject.bounds.width).to eq(100)
-          expect(subject.bounds.height).to eq(200)
+          transform = Glove::Components::Transform.new
+          transform.width = 100_f32
+          transform.height = 200_f32
+          transform.translate_x = 10_f32
+          transform.translate_y = 20_f32
 
-          expect(subject.bounds.top).to eq(100 + 20)
-          expect(subject.bounds.bottom).to eq(-100 + 20)
+          transform.bounds.width.should eq(100)
+          transform.bounds.height.should eq(200)
 
-          expect(subject.bounds.left).to eq(-50 + 10)
-          expect(subject.bounds.right).to eq(50 + 10)
+          transform.bounds.top.should eq(100 + 20)
+          transform.bounds.bottom.should eq(-100 + 20)
+
+          transform.bounds.left.should eq(-50 + 10)
+          transform.bounds.right.should eq(50 + 10)
         end
       end
 
       context "rotated" do
-        before do
-          subject.angle = 0.174533_f32 # 10 degrees
-        end
-
         it "returns the proper bounds" do
-          expect(subject.bounds.width.to_f64).to be_close(133.21, 0.01)
-          expect(subject.bounds.height.to_f64).to be_close(214.326, 0.01)
+          transform = Glove::Components::Transform.new
+          transform.width = 100_f32
+          transform.height = 200_f32
+          transform.angle = 0.174533_f32 # 10 degrees
 
-          expect(subject.bounds.top.to_f64).to be_close(214.326 / 2, 0.01)
-          expect(subject.bounds.bottom.to_f64).to be_close(- 214.326 / 2, 0.01)
+          transform.bounds.width.to_f64.should be_close(133.21, 0.01)
+          transform.bounds.height.to_f64.should be_close(214.326, 0.01)
 
-          expect(subject.bounds.left.to_f64).to be_close(- 133.21 / 2, 0.01)
-          expect(subject.bounds.right.to_f64).to be_close(133.21 / 2, 0.01)
+          transform.bounds.top.to_f64.should be_close(214.326 / 2, 0.01)
+          transform.bounds.bottom.to_f64.should be_close(- 214.326 / 2, 0.01)
+
+          transform.bounds.left.to_f64.should be_close(- 133.21 / 2, 0.01)
+          transform.bounds.right.to_f64.should be_close(133.21 / 2, 0.01)
         end
 
         context "translated" do
-          before do
-            subject.translate_x = 10_f32
-            subject.translate_y = 20_f32
-          end
-
           it "returns the proper bounds" do
-            expect(subject.bounds.width.to_f64).to be_close(133.21, 0.01)
-            expect(subject.bounds.height.to_f64).to be_close(214.326, 0.01)
+            transform = Glove::Components::Transform.new
+            transform.width = 100_f32
+            transform.height = 200_f32
+            transform.angle = 0.174533_f32 # 10 degrees
+            transform.translate_x = 10_f32
+            transform.translate_y = 20_f32
 
-            expect(subject.bounds.top.to_f64).to be_close(214.326 / 2 + 20, 0.01)
-            expect(subject.bounds.bottom.to_f64).to be_close(- 214.326 / 2 + 20, 0.01)
+            transform.bounds.width.to_f64.should be_close(133.21, 0.01)
+            transform.bounds.height.to_f64.should be_close(214.326, 0.01)
 
-            expect(subject.bounds.left.to_f64).to be_close(- 133.21 / 2 + 10, 0.01)
-            expect(subject.bounds.right.to_f64).to be_close(133.21 / 2 + 10, 0.01)
+            transform.bounds.top.to_f64.should be_close(214.326 / 2 + 20, 0.01)
+            transform.bounds.bottom.to_f64.should be_close(- 214.326 / 2 + 20, 0.01)
+
+            transform.bounds.left.to_f64.should be_close(- 133.21 / 2 + 10, 0.01)
+            transform.bounds.right.to_f64.should be_close(133.21 / 2 + 10, 0.01)
           end
         end
       end
 
       context "scaled" do
-        before do
-          subject.scale_x = 3.0_f32
-          subject.scale_y = 0.5_f32
-        end
-
         it "returns the proper bounds" do
-          expect(subject.bounds.width).to eq(300)
-          expect(subject.bounds.height).to eq(100)
+          transform = Glove::Components::Transform.new
+          transform.scale_x = 3.0_f32
+          transform.scale_y = 0.5_f32
+          transform.width = 100_f32
+          transform.height = 200_f32
 
-          expect(subject.bounds.top).to eq(200 / 2 * 0.5)
-          expect(subject.bounds.bottom).to eq(-200 / 2  * 0.5)
+          transform.bounds.width.should eq(300)
+          transform.bounds.height.should eq(100)
 
-          expect(subject.bounds.left).to eq(- 100 / 2 * 3.0)
-          expect(subject.bounds.right).to eq(100 / 2 * 3.0)
+          transform.bounds.top.should eq(200 / 2 * 0.5)
+          transform.bounds.bottom.should eq(-200 / 2  * 0.5)
+
+          transform.bounds.left.should eq(- 100 / 2 * 3.0)
+          transform.bounds.right.should eq(100 / 2 * 3.0)
         end
 
         context "translated" do
-          before do
-            subject.translate_x = 10_f32
-            subject.translate_y = 20_f32
-          end
-
           it "returns the proper bounds" do
-            expect(subject.bounds.width).to eq(300)
-            expect(subject.bounds.height).to eq(100)
+            transform = Glove::Components::Transform.new
+            transform.translate_x = 10_f32
+            transform.translate_y = 20_f32
+            transform.scale_x = 3.0_f32
+            transform.scale_y = 0.5_f32
+            transform.width = 100_f32
+            transform.height = 200_f32
 
-            expect(subject.bounds.top).to eq(200 / 2 * 0.5 + 20)
-            expect(subject.bounds.bottom).to eq(-200 / 2  * 0.5 + 20)
+            transform.bounds.width.should eq(300)
+            transform.bounds.height.should eq(100)
 
-            expect(subject.bounds.left).to eq(- 100 / 2 * 3.0 + 10)
-            expect(subject.bounds.right).to eq(100 / 2 * 3.0 + 10)
+            transform.bounds.top.should eq(200 / 2 * 0.5 + 20)
+            transform.bounds.bottom.should eq(-200 / 2  * 0.5 + 20)
+
+            transform.bounds.left.should eq(- 100 / 2 * 3.0 + 10)
+            transform.bounds.right.should eq(100 / 2 * 3.0 + 10)
           end
         end
 
@@ -142,37 +151,41 @@ Spec2.describe Glove::Components::Transform do
       end
 
       context "anchored" do
-        before do
-          subject.anchor_x = 0.25_f32
-          subject.anchor_y = 1.0_f32
-        end
-
         it "returns the proper bounds" do
-          expect(subject.bounds.width).to eq(100)
-          expect(subject.bounds.height).to eq(200)
+          transform = Glove::Components::Transform.new
+          transform.anchor_x = 0.25_f32
+          transform.anchor_y = 1.0_f32
+          transform.width = 100_f32
+          transform.height = 200_f32
 
-          expect(subject.bounds.top).to eq(0)
-          expect(subject.bounds.bottom).to eq(-200)
+          transform.bounds.width.should eq(100)
+          transform.bounds.height.should eq(200)
 
-          expect(subject.bounds.left).to eq(-25)
-          expect(subject.bounds.right).to eq(75)
+          transform.bounds.top.should eq(0)
+          transform.bounds.bottom.should eq(-200)
+
+          transform.bounds.left.should eq(-25)
+          transform.bounds.right.should eq(75)
         end
 
         context "translated" do
-          before do
-            subject.translate_x = 10_f32
-            subject.translate_y = 20_f32
-          end
-
           it "returns the proper bounds" do
-            expect(subject.bounds.width).to eq(100)
-            expect(subject.bounds.height).to eq(200)
+            transform = Glove::Components::Transform.new
+            transform.translate_x = 10_f32
+            transform.translate_y = 20_f32
+            transform.anchor_x = 0.25_f32
+            transform.anchor_y = 1.0_f32
+            transform.width = 100_f32
+            transform.height = 200_f32
 
-            expect(subject.bounds.top).to eq(0 + 20)
-            expect(subject.bounds.bottom).to eq(-200 + 20)
+            transform.bounds.width.should eq(100)
+            transform.bounds.height.should eq(200)
 
-            expect(subject.bounds.left).to eq(-25 + 10)
-            expect(subject.bounds.right).to eq(75 + 10)
+            transform.bounds.top.should eq(0 + 20)
+            transform.bounds.bottom.should eq(-200 + 20)
+
+            transform.bounds.left.should eq(-25 + 10)
+            transform.bounds.right.should eq(75 + 10)
           end
         end
 
@@ -180,37 +193,45 @@ Spec2.describe Glove::Components::Transform do
         # TODO: anchored+rotated+translated
 
         context "scaled" do
-          before do
-            subject.scale_x = 3.0_f32
-            subject.scale_y = 0.5_f32
-          end
-
           it "returns the proper bounds" do
-            expect(subject.bounds.width).to eq(300)
-            expect(subject.bounds.height).to eq(100)
+            transform = Glove::Components::Transform.new
+            transform.scale_x = 3.0_f32
+            transform.scale_y = 0.5_f32
+            transform.anchor_x = 0.25_f32
+            transform.anchor_y = 1.0_f32
+            transform.width = 100_f32
+            transform.height = 200_f32
 
-            expect(subject.bounds.top).to eq(0)
-            expect(subject.bounds.bottom).to eq(-100)
+            transform.bounds.width.should eq(300)
+            transform.bounds.height.should eq(100)
 
-            expect(subject.bounds.left).to eq(-25 * 3)
-            expect(subject.bounds.right).to eq(75 * 3)
+            transform.bounds.top.should eq(0)
+            transform.bounds.bottom.should eq(-100)
+
+            transform.bounds.left.should eq(-25 * 3)
+            transform.bounds.right.should eq(75 * 3)
           end
 
           context "translated" do
-            before do
-              subject.translate_x = 10_f32
-              subject.translate_y = 20_f32
-            end
-
             it "returns the proper bounds" do
-              expect(subject.bounds.width).to eq(300)
-              expect(subject.bounds.height).to eq(100)
+              transform = Glove::Components::Transform.new
+              transform.translate_x = 10_f32
+              transform.translate_y = 20_f32
+              transform.anchor_x = 0.25_f32
+              transform.anchor_y = 1.0_f32
+              transform.scale_x = 3.0_f32
+              transform.scale_y = 0.5_f32
+              transform.width = 100_f32
+              transform.height = 200_f32
 
-              expect(subject.bounds.top).to eq(0 + 20)
-              expect(subject.bounds.bottom).to eq(-100 + 20)
+              transform.bounds.width.should eq(300)
+              transform.bounds.height.should eq(100)
 
-              expect(subject.bounds.left).to eq(-25 * 3 + 10)
-              expect(subject.bounds.right).to eq(75 * 3 + 10)
+              transform.bounds.top.should eq(0 + 20)
+              transform.bounds.bottom.should eq(-100 + 20)
+
+              transform.bounds.left.should eq(-25 * 3 + 10)
+              transform.bounds.right.should eq(75 * 3 + 10)
             end
           end
 

--- a/spec/point_spec.cr
+++ b/spec/point_spec.cr
@@ -1,51 +1,40 @@
-require "spec2"
+require "spec"
 require "../src/glove"
 
-Spec2.describe Glove::Point do
-  subject { Glove::Point.new(x, y) }
-
-  let(x) { 100_f32 }
-  let(y) { 200_f32 }
-
+describe Glove::Point do
   describe "#+ - add" do
-    subject { super + other }
-
-    let(other_dx) { 10_f32 }
-    let(other_dy) { 20_f32 }
-
-    let(other) { Glove::Vector.new(other_dx, other_dy) }
-
     it "adds" do
-      expect(subject.x).to eq(110)
-      expect(subject.y).to eq(220)
+      point = Glove::Point.new(100f32, 200f32)
+      vector = Glove::Vector.new(10f32, 20f32)
+
+      res = point + vector
+      res.should be_a(Glove::Point)
+      res.x.should eq(110)
+      res.y.should eq(220)
     end
   end
 
   describe "#- - subtract point" do
-    subject { super - other }
-
-    let(other_x) { 10_f32 }
-    let(other_y) { 20_f32 }
-
-    let(other) { Glove::Point.new(other_x, other_y) }
-
     it "subtracts" do
-      expect(subject.dx).to eq(90)
-      expect(subject.dy).to eq(180)
+      point = Glove::Point.new(100f32, 200f32)
+      other_point = Glove::Point.new(10f32, 20f32)
+
+      res = point - other_point
+      res.should be_a(Glove::Vector)
+      res.dx.should eq(90)
+      res.dy.should eq(180)
     end
   end
 
   describe "#- - subtract vector" do
-    subject { super - other }
-
-    let(other_dx) { 10_f32 }
-    let(other_dy) { 20_f32 }
-
-    let(other) { Glove::Vector.new(other_dx, other_dy) }
-
     it "subtracts" do
-      expect(subject.x).to eq(90)
-      expect(subject.y).to eq(180)
+      point = Glove::Point.new(100f32, 200f32)
+      vector = Glove::Vector.new(10f32, 20f32)
+
+      res = point - vector
+      res.should be_a(Glove::Point)
+      res.x.should eq(90)
+      res.y.should eq(180)
     end
   end
 end

--- a/spec/rect_spec.cr
+++ b/spec/rect_spec.cr
@@ -1,48 +1,59 @@
-require "spec2"
+require "spec"
 require "../src/glove"
 
-Spec2.describe Glove::Rect do
-  subject { Glove::Rect.new(origin, size) }
-
-  let(origin) { Glove::Point.new(origin_x, origin_y) }
-  let(size) { Glove::Size.new(width, height) }
-
-  let(origin_x) { 100_f32 }
-  let(origin_y) { 200_f32 }
-  let(width) { 300_f32 }
-  let(height) { 400_f32 }
-
+describe Glove::Rect do
   it "has correct derived attributes" do
-    expect(subject.width).to eq(300)
-    expect(subject.height).to eq(400)
-    expect(subject.left).to eq(100)
-    expect(subject.right).to eq(100 + 300)
-    expect(subject.top).to eq(200 + 400)
-    expect(subject.bottom).to eq(200)
+    origin_x = 100f32
+    origin_y = 200f32
+    origin = Glove::Point.new(origin_x, origin_y)
+    width = 300f32
+    height = 400f32
+    size = Glove::Size.new(width, height)
+    rect = Glove::Rect.new(origin, size)
+
+    rect.width.should eq(300)
+    rect.height.should eq(400)
+    rect.left.should eq(100)
+    rect.right.should eq(100 + 300)
+    rect.top.should eq(200 + 400)
+    rect.bottom.should eq(200)
   end
 
   describe "#grow" do
-    subject { super.grow(1_f32) }
-
     it "grows properly" do
-      expect(subject.left).to eq(99)
-      expect(subject.right).to eq(401)
-      expect(subject.top).to eq(601)
-      expect(subject.bottom).to eq(199)
+      origin_x = 100f32
+      origin_y = 200f32
+      origin = Glove::Point.new(origin_x, origin_y)
+      width = 300f32
+      height = 400f32
+      size = Glove::Size.new(width, height)
+      rect = Glove::Rect.new(origin, size)
+
+      rect = rect.grow(1f32)
+
+      rect.left.should eq(99)
+      rect.right.should eq(401)
+      rect.top.should eq(601)
+      rect.bottom.should eq(199)
     end
   end
 
   describe "#grow_y" do
-    subject { super.grow_y(1_f32) }
+    it "grows Y, but keeps left/right unchanged" do
+      origin_x = 100f32
+      origin_y = 200f32
+      origin = Glove::Point.new(origin_x, origin_y)
+      width = 300f32
+      height = 400f32
+      size = Glove::Size.new(width, height)
+      rect = Glove::Rect.new(origin, size)
 
-    it "keeps left/right unchanged" do
-      expect(subject.left).to eq(100)
-      expect(subject.right).to eq(400)
-    end
+      rect = rect.grow_y(1f32)
 
-    it "grows properly" do
-      expect(subject.top).to eq(601)
-      expect(subject.bottom).to eq(199)
+      rect.left.should eq(100)
+      rect.right.should eq(400)
+      rect.top.should eq(601)
+      rect.bottom.should eq(199)
     end
   end
 

--- a/spec/space_spec.cr
+++ b/spec/space_spec.cr
@@ -1,4 +1,4 @@
-require "spec2"
+require "spec"
 require "../src/glove"
 
 class GloveSpaceSpecTestComponent < ::Glove::Component
@@ -41,53 +41,55 @@ class GloveSpaceSpecTestApp < Glove::AbstractApp
   end
 end
 
-Spec2.describe Glove::Space do
-  let(space) { Glove::Space.new }
-  subject { space }
-
+describe Glove::Space do
   context "new space" do
     it "is empty" do
-      expect(subject.entities.size).to eq(0)
-      expect(subject.actions.size).to eq(0)
-      expect(subject.systems.size).to eq(0)
+      space = Glove::Space.new
+
+      space.entities.size.should eq(0)
+      space.actions.size.should eq(0)
+      space.systems.size.should eq(0)
     end
   end
 
   describe "#update" do
-    subject { space.update(0.123, app) }
-
-    let(app) { GloveSpaceSpecTestApp.new(800, 600, "hello world") }
-
     context "one entity" do
-      before { space.entities << entity }
-
-      let(entity) do
-        Glove::Entity.new.tap do |e|
-          e << GloveSpaceSpecTestComponent.new
-        end
-      end
-
       it "updates" do
-        expect(entity[GloveSpaceSpecTestComponent].updated).to eq(false)
-        subject
-        expect(entity[GloveSpaceSpecTestComponent].updated).to eq(true)
-      end
+        space = Glove::Space.new
+        app = GloveSpaceSpecTestApp.new(800, 600, "hello world")
 
-      context "child entity" do
-        before { entity.children << child_entity }
-
-        let(child_entity) do
+        parent_entity =
           Glove::Entity.new.tap do |e|
             e << GloveSpaceSpecTestComponent.new
           end
-        end
+        space.entities << parent_entity
 
+        parent_entity[GloveSpaceSpecTestComponent].updated.should eq(false)
+        space.update(0.123, app)
+        parent_entity[GloveSpaceSpecTestComponent].updated.should eq(true)
+      end
+
+      context "child entity" do
         it "updates" do
-          expect(entity[GloveSpaceSpecTestComponent].updated).to eq(false)
-          expect(child_entity[GloveSpaceSpecTestComponent].updated).to eq(false)
-          subject
-          expect(entity[GloveSpaceSpecTestComponent].updated).to eq(true)
-          expect(child_entity[GloveSpaceSpecTestComponent].updated).to eq(true)
+          space = Glove::Space.new
+          app = GloveSpaceSpecTestApp.new(800, 600, "hello world")
+
+          parent_entity =
+            Glove::Entity.new.tap do |e|
+              e << GloveSpaceSpecTestComponent.new
+            end
+          child_entity =
+            Glove::Entity.new.tap do |e|
+              e << GloveSpaceSpecTestComponent.new
+            end
+          parent_entity.children << child_entity
+          space.entities << parent_entity
+
+          parent_entity[GloveSpaceSpecTestComponent].updated.should eq(false)
+          child_entity[GloveSpaceSpecTestComponent].updated.should eq(false)
+          space.update(0.123, app)
+          parent_entity[GloveSpaceSpecTestComponent].updated.should eq(true)
+          child_entity[GloveSpaceSpecTestComponent].updated.should eq(true)
         end
       end
     end

--- a/spec/tween_spec.cr
+++ b/spec/tween_spec.cr
@@ -1,134 +1,174 @@
-require "spec2"
+require "spec"
 require "../src/glove"
 
-Spec2.describe Glove::Tween do
-  subject { Glove::Tween.new(duration, kind) }
-
-  let(duration) { 1.2_f32 }
-  let(kind) { Glove::Tween::Kind::Linear }
-
+describe Glove::Tween do
   context "at start" do
     it "has progress 0%" do
-      expect(subject.fraction.to_f64).to be_close(0.0, 0.001)
-      expect(subject.linear_fraction.to_f64).to be_close(0.0, 0.001)
-      expect(subject.complete?).to eq(false)
+      tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::Linear)
+
+      tween.fraction.to_f64.should be_close(0.0, 0.001)
+      tween.linear_fraction.to_f64.should be_close(0.0, 0.001)
+      tween.complete?.should be_false
     end
   end
 
   context "25% through" do
-    before do
-      subject.update(0.3_f32)
-    end
-
     it "has progress 25%" do
-      expect(subject.linear_fraction.to_f64).to be_close(0.25, 0.001)
-      expect(subject.complete?).to eq(false)
+      tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::Linear)
+      tween.update(0.3f32)
+
+      tween.linear_fraction.to_f64.should be_close(0.25, 0.001)
+      tween.complete?.should be_false
     end
 
     context "linear" do
-      let(kind) { Glove::Tween::Kind::Linear }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.25, 0.001) }
+      it "has correct fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::Linear)
+        tween.update(0.3f32)
+
+        tween.fraction.to_f64.should be_close(0.25, 0.001)
+      end
     end
 
     context "ease in" do
-      let(kind) { Glove::Tween::Kind::EaseIn }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.015625, 0.001) }
+      it "has correct fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseIn)
+        tween.update(0.3f32)
+
+        tween.fraction.to_f64.should be_close(0.015625, 0.001)
+      end
     end
 
     context "ease out" do
-      let(kind) { Glove::Tween::Kind::EaseOut }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.578125, 0.001) }
+      it "has correct fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseOut)
+        tween.update(0.3f32)
+
+        tween.fraction.to_f64.should be_close(0.578125, 0.001)
+      end
     end
 
     context "ease in out" do
-      let(kind) { Glove::Tween::Kind::EaseInOut }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.0625, 0.001) }
+      it "has correct fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseInOut)
+        tween.update(0.3f32)
+
+        tween.fraction.to_f64.should be_close(0.0625, 0.001)
+      end
     end
   end
 
   context "halfway" do
-    before do
-      subject.update(0.6_f32)
-    end
-
     it "has progress 50%" do
-      expect(subject.linear_fraction.to_f64).to be_close(0.5, 0.001)
-      expect(subject.complete?).to eq(false)
+      tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::Linear)
+      tween.update(0.6f32)
+
+      tween.linear_fraction.to_f64.should be_close(0.5, 0.001)
+      tween.complete?.should be_false
     end
 
     context "linear" do
-      let(kind) { Glove::Tween::Kind::Linear }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.5, 0.001) }
+      it "has proper fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::Linear)
+        tween.update(0.6f32)
+
+        tween.fraction.to_f64.should be_close(0.5, 0.001)
+      end
     end
 
     context "ease in" do
-      let(kind) { Glove::Tween::Kind::EaseIn }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.125, 0.001) }
+      it "has proper fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseIn)
+        tween.update(0.6f32)
+
+        tween.fraction.to_f64.should be_close(0.125, 0.001)
+      end
     end
 
     context "ease out" do
-      let(kind) { Glove::Tween::Kind::EaseOut }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.875, 0.001) }
+      it "has proper fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseOut)
+        tween.update(0.6f32)
+
+        tween.fraction.to_f64.should be_close(0.875, 0.001)
+      end
     end
 
     context "ease in out" do
-      let(kind) { Glove::Tween::Kind::EaseInOut }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.5, 0.001) }
+      it "has proper fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseInOut)
+        tween.update(0.6f32)
+
+        tween.fraction.to_f64.should be_close(0.5, 0.001)
+      end
     end
   end
 
   context "75% through" do
-    before do
-      subject.update(0.9_f32)
-    end
-
     it "has progress 75%" do
-      expect(subject.linear_fraction.to_f64).to be_close(0.75, 0.001)
-      expect(subject.complete?).to eq(false)
+      tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::Linear)
+      tween.update(0.9f32)
+
+      tween.linear_fraction.to_f64.should be_close(0.75, 0.001)
+      tween.complete?.should be_false
     end
 
     context "linear" do
-      let(kind) { Glove::Tween::Kind::Linear }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.75, 0.001) }
+      it "has proper fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::Linear)
+        tween.update(0.9f32)
+
+        tween.fraction.to_f64.should be_close(0.75, 0.001)
+      end
     end
 
     context "ease in" do
-      let(kind) { Glove::Tween::Kind::EaseIn }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.421875, 0.001) }
+      it "has proper fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseIn)
+        tween.update(0.9f32)
+
+        tween.fraction.to_f64.should be_close(0.421875, 0.001)
+      end
     end
 
     context "ease out" do
-      let(kind) { Glove::Tween::Kind::EaseOut }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.984375, 0.001) }
+      it "has proper fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseOut)
+        tween.update(0.9f32)
+
+        tween.fraction.to_f64.should be_close(0.984375, 0.001)
+      end
     end
 
     context "ease in out" do
-      let(kind) { Glove::Tween::Kind::EaseInOut }
-      it "" { expect(subject.fraction.to_f64).to be_close(0.9375, 0.001) }
+      it "has proper fraction" do
+        tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseInOut)
+        tween.update(0.9f32)
+
+        tween.fraction.to_f64.should be_close(0.9375, 0.001)
+      end
     end
   end
 
   context "at end" do
-    before do
-      subject.update(1.2_f32)
-    end
-
     it "has progress 100%" do
-      expect(subject.fraction).to eq(1.0)
-      expect(subject.linear_fraction).to eq(1.0)
-      expect(subject.complete?).to eq(true)
+      tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseInOut)
+      tween.update(1.2f32)
+
+      tween.fraction.should eq(1.0)
+      tween.linear_fraction.should eq(1.0)
+      tween.complete?.should be_true
     end
   end
 
   context "past end" do
-    before do
-      subject.update(1.3_f32)
-    end
-
     it "has progress 100%" do
-      expect(subject.fraction).to eq(1.0)
-      expect(subject.linear_fraction).to eq(1.0)
-      expect(subject.complete?).to eq(true)
+      tween = Glove::Tween.new(1.2f32, Glove::Tween::Kind::EaseInOut)
+      tween.update(1.3f32)
+
+      tween.fraction.should eq(1.0)
+      tween.linear_fraction.should eq(1.0)
+      tween.complete?.should be_true
     end
   end
 end

--- a/spec/vector_spec.cr
+++ b/spec/vector_spec.cr
@@ -1,59 +1,46 @@
-require "spec2"
+require "spec"
 require "../src/glove"
 
-Spec2.describe Glove::Vector do
-  subject { Glove::Vector.new(dx, dy) }
-
-  let(dx) { 100_f32 }
-  let(dy) { 200_f32 }
-
+describe Glove::Vector do
   describe "#+ - add" do
-    subject { super + other }
-
-    let(other_dx) { 10_f32 }
-    let(other_dy) { 20_f32 }
-
-    let(other) { Glove::Vector.new(other_dx, other_dy) }
-
     it "adds" do
-      expect(subject.dx).to eq(110)
-      expect(subject.dy).to eq(220)
+      vector = Glove::Vector.new(100f32, 200f32)
+      other_vector = Glove::Vector.new(10f32, 20f32)
+
+      res = vector + other_vector
+      res.dx.should eq(110)
+      res.dy.should eq(220)
     end
   end
 
   describe "#- - subtract" do
-    subject { super - other }
-
-    let(other_dx) { 10_f32 }
-    let(other_dy) { 20_f32 }
-
-    let(other) { Glove::Vector.new(other_dx, other_dy) }
-
     it "subtracts" do
-      expect(subject.dx).to eq(90)
-      expect(subject.dy).to eq(180)
+      vector = Glove::Vector.new(100f32, 200f32)
+      other_vector = Glove::Vector.new(10f32, 20f32)
+
+      res = vector - other_vector
+      res.dx.should eq(90)
+      res.dy.should eq(180)
     end
   end
 
   describe "#* - scalar multiply" do
-    subject { super * other }
-
-    let(other) { 0.1 }
-
     it "multiplies" do
-      expect(subject.dx).to eq(10)
-      expect(subject.dy).to eq(20)
+      vector = Glove::Vector.new(100f32, 200f32)
+
+      res = vector * 0.1
+      res.dx.should eq(10)
+      res.dy.should eq(20)
     end
   end
 
   describe "#* - scalar divide" do
-    subject { super / other }
-
-    let(other) { 10 }
-
     it "divides" do
-      expect(subject.dx).to eq(10)
-      expect(subject.dy).to eq(20)
+      vector = Glove::Vector.new(100f32, 200f32)
+
+      res = vector / 10
+      res.dx.should eq(10)
+      res.dy.should eq(20)
     end
   end
 end


### PR DESCRIPTION
spec2 is a little flaky, and so this PR converts the tests to use the built-in Crystal `spec`.

This will still fail on Travis CI because of crystal-lang/crystal/issues/4647.