### PR TITLE
Introduce gl_checked_void for compat with Crystal 0.23

### DIFF
--- a/src/gl/gl.cr
+++ b/src/gl/gl.cr
@@ -10,6 +10,16 @@ macro gl_checked(call)
   value
 end
 
+macro gl_checked_void(call)
+  {{call}}
+  error = LibGL.get_error
+  if error != LibGL::NO_ERROR
+    details = "#{error} / #{GL.error_to_s(error)}"
+    raise "OpenGL call failed: " + {{call.stringify}} + ": #{details}"
+  end
+  nil
+end
+
 module Glove::GL
   def self.check_error(where="")
     if error = GL.last_error

--- a/src/quad.cr
+++ b/src/quad.cr
@@ -29,7 +29,7 @@ class Glove::Quad
     LibGL.gen_vertex_arrays(1, out my_vertex_array_id)
 
     # VAO
-    gl_checked(LibGL.bind_vertex_array(my_vertex_array_id))
+    gl_checked_void(LibGL.bind_vertex_array(my_vertex_array_id))
 
     # VBO
     LibGL.bind_buffer(LibGL::ARRAY_BUFFER, vertex_buffer)
@@ -47,7 +47,7 @@ class Glove::Quad
     LibGL.vertex_attrib_pointer(0_u32, 2, LibGL::FLOAT, LibGL::FALSE, stride, nil)
     LibGL.vertex_attrib_pointer(1_u32, 2, LibGL::FLOAT, LibGL::FALSE, stride, offset)
 
-    gl_checked(LibGL.bind_vertex_array(0))
+    gl_checked_void(LibGL.bind_vertex_array(0))
 
     @vertex_array_id = my_vertex_array_id
   end

--- a/src/renderer.cr
+++ b/src/renderer.cr
@@ -56,7 +56,7 @@ class Glove::Renderer
     if texture_id > 0
       gl_checked(@shader_program.set_uniform_1i("textured", 1))
       gl_checked(@shader_program.set_uniform_4f("spriteColor", 1.0, 1.0, 1.0, 1.0))
-      gl_checked(LibGL.bind_texture(LibGL::TEXTURE_2D, texture_id))
+      gl_checked_void(LibGL.bind_texture(LibGL::TEXTURE_2D, texture_id))
     else
       gl_checked(@shader_program.set_uniform_1i("textured", 0))
     end
@@ -73,9 +73,9 @@ class Glove::Renderer
       gl_checked(@shader_program.set_uniform_1f("z", z_for(entity)))
 
       quad = quad_for(entity)
-      gl_checked(LibGL.bind_vertex_array(quad.vertex_array_id))
-      gl_checked(LibGL.draw_arrays(LibGL::TRIANGLE_STRIP, 0, quad.vertices.size))
-      gl_checked(LibGL.bind_vertex_array(0))
+      gl_checked_void(LibGL.bind_vertex_array(quad.vertex_array_id))
+      gl_checked_void(LibGL.draw_arrays(LibGL::TRIANGLE_STRIP, 0, quad.vertices.size))
+      gl_checked_void(LibGL.bind_vertex_array(0))
     end
 
     parent_matrix = transform_matrix_as_parent(entity)

--- a/src/texture.cr
+++ b/src/texture.cr
@@ -18,13 +18,13 @@ class Glove::Texture
         raise "Cannot convert comp #{comp}"
       end
 
-    gl_checked(LibGL.bind_texture(LibGL::TEXTURE_2D, texture_id))
-    gl_checked(LibGL.tex_parameteri(LibGL::TEXTURE_2D, LibGL::TEXTURE_MIN_FILTER, LibGL::LINEAR))
-    gl_checked(LibGL.tex_parameteri(LibGL::TEXTURE_2D, LibGL::TEXTURE_MAG_FILTER, LibGL::LINEAR))
-    gl_checked(LibGL.tex_parameteri(LibGL::TEXTURE_2D, LibGL::TEXTURE_WRAP_S, LibGL::REPEAT))
-    gl_checked(LibGL.tex_parameteri(LibGL::TEXTURE_2D, LibGL::TEXTURE_WRAP_T, LibGL::REPEAT))
+    gl_checked_void(LibGL.bind_texture(LibGL::TEXTURE_2D, texture_id))
+    gl_checked_void(LibGL.tex_parameteri(LibGL::TEXTURE_2D, LibGL::TEXTURE_MIN_FILTER, LibGL::LINEAR))
+    gl_checked_void(LibGL.tex_parameteri(LibGL::TEXTURE_2D, LibGL::TEXTURE_MAG_FILTER, LibGL::LINEAR))
+    gl_checked_void(LibGL.tex_parameteri(LibGL::TEXTURE_2D, LibGL::TEXTURE_WRAP_S, LibGL::REPEAT))
+    gl_checked_void(LibGL.tex_parameteri(LibGL::TEXTURE_2D, LibGL::TEXTURE_WRAP_T, LibGL::REPEAT))
 
-    gl_checked(LibGL.tex_image_2d(
+    gl_checked_void(LibGL.tex_image_2d(
       LibGL::TEXTURE_2D,
       0,
       image_type,
@@ -36,7 +36,7 @@ class Glove::Texture
       data.as(Void*)))
 
     LibSTBImage.free(data)
-    gl_checked(LibGL.bind_texture(LibGL::TEXTURE_2D, 0))
+    gl_checked_void(LibGL.bind_texture(LibGL::TEXTURE_2D, 0))
 
     new(texture_id, width, height)
   end


### PR DESCRIPTION
`val = LibSomething.blah` fails on Crystal 0.23 if the `blah` lib function returns void and is assigned to a variable. This breaks the `gl_checked` macro, hence the `gl_checked_void` macro.