### PR TITLE
Improve ChangeColor action

### DIFF
--- a/spec/actions/change_color_spec.cr
+++ b/spec/actions/change_color_spec.cr
@@ -1,0 +1,64 @@
+require "spec"
+require "../../src/glove"
+
+describe Glove::Actions::ChangeColor do
+  describe "#initialize" do
+    it "sets reasonable defaults" do
+      start_color = Glove::Color.new(1.0_f32, 1.0_f32, 1.0_f32, 1.0_f32)
+      end_color = Glove::Color.new(1.0_f32, 1.0_f32, 1.0_f32, 1.0_f32)
+      tween = Glove::Tween::Kind::Linear
+      duration = 1.0_f32
+
+      entity = Glove::Entity.new.tap do |e|
+        e << Glove::Components::Color.new(start_color)
+      end
+
+      action = Glove::Actions::ChangeColor.new(entity, end_color, duration, tween)
+      action.should be_truthy
+    end
+  end
+
+  describe "#update" do
+    start_color = Glove::Color.new(1.0_f32, 1.0_f32, 1.0_f32, 1.0_f32)
+    mid_color = Glove::Color.new(0.5_f32, 0.5_f32, 0.5_f32, 0.5_f32)
+    end_color = Glove::Color.new(0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32)
+    tween = Glove::Tween::Kind::Linear
+    duration = 1.0_f32
+
+    color_component = Glove::Components::Color.new(start_color)
+
+    entity = Glove::Entity.new.tap do |e|
+      e << color_component
+    end
+
+    it "should change the entity color" do
+      action = Glove::Actions::ChangeColor.new(entity, end_color, duration, tween)
+      action.update(duration)
+
+      if component = entity[Glove::Components::Color]?
+        color = component.color
+        color.r.should eq(end_color.r)
+        color.g.should eq(end_color.g)
+        color.b.should eq(end_color.b)
+        color.a.should eq(end_color.a)
+      else
+        raise "should have a color component"
+      end
+    end
+
+    it "should continue from the last state" do
+      action = Glove::Actions::ChangeColor.new(entity, start_color, duration, tween)
+      action.update(0.5_f32)
+
+      if component = entity[Glove::Components::Color]?
+        color = component.color
+        color.r.should eq(mid_color.r)
+        color.g.should eq(mid_color.g)
+        color.b.should eq(mid_color.b)
+        color.a.should eq(mid_color.a)
+      else
+        raise "should have a color component"
+      end
+    end
+  end
+end

--- a/src/actions/change_color.cr
+++ b/src/actions/change_color.cr
@@ -1,15 +1,16 @@
 class Glove::Actions::ChangeColor < Glove::IntervalAction
   def initialize(@entity : Glove::Entity, @new_color : Glove::Color, duration : Float32, tween_kind : Glove::Tween::Kind)
     @tween = Glove::Tween.new(duration, tween_kind)
+    super(duration)
+  end
 
-    if color_component = @entity[Glove::Components::Color]?
-      @original_color = color_component.color
+  private def original_color
+    @original_color ||= if color_component = @entity[Glove::Components::Color]?
+      color_component.color
     else
       # FIXME: does this make sense?
-      @original_color = Glove::Color.new(0_f32, 0_f32, 0_f32, 0_f32)
+      Glove::Color.new(0_f32, 0_f32, 0_f32, 0_f32)
     end
-
-    super(duration)
   end
 
   def update(delta_time)
@@ -19,6 +20,6 @@ class Glove::Actions::ChangeColor < Glove::IntervalAction
     return if @tween.complete?
     @tween.update(delta_time)
 
-    color_component.color = @original_color.lerp(@new_color, @tween.fraction)
+    color_component.color = original_color.lerp(@new_color, @tween.fraction)
   end
 end

--- a/src/color.cr
+++ b/src/color.cr
@@ -12,12 +12,13 @@ struct Glove::Color
 
   def lerp(other : Glove::Color, t : Float32)
     t = { {0_f32, t}.max, 1_f32}.min
+    tn = 1.0_f32 - t
 
     Glove::Color.new(
-      (1.0_f32 - t) * r + t * other.r,
-      (1.0_f32 - t) * g + t * other.g,
-      (1.0_f32 - t) * b + t * other.b,
-      (1.0_f32 - t) * a + t * other.a,
+      tn * r + t * other.r,
+      tn * g + t * other.g,
+      tn * b + t * other.b,
+      tn * a + t * other.a,
     )
   end
 end


### PR DESCRIPTION
It seems that `Glove::Actions::ChangeColor` binds the `original_color` value at the time of initialization, not first run, which means that, in a sequence, it will not continue from the state at which the action began but rather the state at which it was initialized. This fixes that.